### PR TITLE
update pod.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GIT_COMMIT_ID ?= $(shell git rev-parse --short HEAD)
 
 # Image URL to use all building/pushing image targets
 REG ?= ghcr.io
-REG_NS ?= ocichina
+REG_NS ?= koordinator-sh
 REG_USER ?= ""
 REG_PWD ?= ""
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GIT_COMMIT_ID ?= $(shell git rev-parse --short HEAD)
 
 # Image URL to use all building/pushing image targets
 REG ?= ghcr.io
-REG_NS ?= koordinator-sh
+REG_NS ?= ocichina
 REG_USER ?= ""
 REG_PWD ?= ""
 
@@ -15,7 +15,7 @@ KOORD_SCHEDULER_IMG ?= "${REG}/${REG_NS}/koord-scheduler:${GIT_BRANCH}-${GIT_COM
 KOORD_DESCHEDULER_IMG ?= "${REG}/${REG_NS}/koord-descheduler:${GIT_BRANCH}-${GIT_COMMIT_ID}"
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.22
+ENVTEST_K8S_VERSION = 1.28
 
 AGENT_MODE ?= hostMode
 # Set license header files.

--- a/pkg/koordlet/metrics/internal_metrics.go
+++ b/pkg/koordlet/metrics/internal_metrics.go
@@ -43,4 +43,5 @@ func init() {
 	internalMustRegister(CoreSchedCollector...)
 	internalMustRegister(ResourceExecutorCollector...)
 	internalMustRegister(KubeletStubCollector...)
+	internalMustRegister(RuntimeHookCollectors...)
 }

--- a/pkg/koordlet/metrics/runtime_hook.go
+++ b/pkg/koordlet/metrics/runtime_hook.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const (
+	// RuntimeHookName represents the hook plugin name of runtime hook.
+	RuntimeHookName = "hook"
+	// RuntimeHookStage represents the stage of invoked runtime hook.
+	RuntimeHookStage = "stage"
+	// RuntimeHookReconcilerLevel represents the level (e.g. pod-level) of invoked runtime hook reconciler.
+	RuntimeHookReconcilerLevel = "level"
+	// RuntimeHookReconcilerResourceType represents the resource type (e.g. cpu.cfs_quota_us) of invoked runtime hook reconciler.
+	RuntimeHookReconcilerResourceType = "resource_type"
+)
+
+var (
+	runtimeHookInvokedDurationMilliSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: KoordletSubsystem,
+		Name:      "runtime_hook_invoked_duration_milliseconds",
+		Help:      "time duration of invocations of runtime hook plugins",
+		// 10us ~ 10.24ms, cgroup <= 40us
+		Buckets: prometheus.ExponentialBuckets(0.01, 4, 8),
+	}, []string{NodeKey, RuntimeHookName, RuntimeHookStage, StatusKey})
+
+	runtimeHookReconcilerInvokedDurationMilliSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: KoordletSubsystem,
+		Name:      "runtime_hook_reconciler_invoked_duration_milliseconds",
+		Help:      "time duration of invocations of runtime hook reconciler plugins",
+		// 10us ~ 10.24ms, cgroup <= 40us
+		Buckets: prometheus.ExponentialBuckets(0.01, 4, 8),
+	}, []string{NodeKey, RuntimeHookReconcilerLevel, RuntimeHookReconcilerResourceType, StatusKey})
+
+	RuntimeHookCollectors = []prometheus.Collector{
+		runtimeHookInvokedDurationMilliSeconds,
+		runtimeHookReconcilerInvokedDurationMilliSeconds,
+	}
+)
+
+func RecordRuntimeHookInvokedDurationMilliSeconds(hookName, stage string, err error, seconds float64) {
+	labels := genNodeLabels()
+	if labels == nil {
+		return
+	}
+	labels[RuntimeHookName] = hookName
+	labels[RuntimeHookStage] = stage
+	labels[StatusKey] = StatusSucceed
+	if err != nil {
+		labels[StatusKey] = StatusFailed
+	}
+	// convert seconds to milliseconds
+	runtimeHookInvokedDurationMilliSeconds.With(labels).Observe(seconds * 1000)
+}
+
+func RecordRuntimeHookReconcilerInvokedDurationMilliSeconds(level, resourceType string, err error, seconds float64) {
+	labels := genNodeLabels()
+	if labels == nil {
+		return
+	}
+	labels[RuntimeHookReconcilerLevel] = level
+	labels[RuntimeHookReconcilerResourceType] = resourceType
+	labels[StatusKey] = StatusSucceed
+	if err != nil {
+		labels[StatusKey] = StatusFailed
+	}
+	// convert seconds to milliseconds
+	runtimeHookReconcilerInvokedDurationMilliSeconds.With(labels).Observe(seconds * 1000)
+}

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -78,9 +78,10 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 		if !containerDir.IsDir() {
 			continue
 		}
-		if _, exist := containerSubDirNames[containerDir.Name()]; !exist {
-			if containerDir.Name().HasSuffix(".scope") {
-				sandboxCandidates = append(sandboxCandidates, containerDir.Name())
+		containerDirName = containerDir.Name()
+		if _, exist := containerSubDirNames[containerDirName]; !exist {
+			if containerDirName.HasSuffix(".scope") {
+				sandboxCandidates = append(sandboxCandidates, containerDirName)
 			}
 		}
 	}

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -79,7 +79,9 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 			continue
 		}
 		if _, exist := containerSubDirNames[containerDir.Name()]; !exist {
-			sandboxCandidates = append(sandboxCandidates, containerDir.Name())
+			if containerDir.Name().HasSuffix(".scope") {
+				sandboxCandidates = append(sandboxCandidates, containerDir.Name())
+			}
 		}
 	}
 

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -54,6 +54,7 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 	cpuSetCgroupRootDir := system.GetRootCgroupSubfsDir(system.CgroupCPUSetDir)
 	podCgroupDir := GetPodCgroupParentDir(pod)
 	podCPUSetCgroupRootDir := filepath.Join(cpuSetCgroupRootDir, podCgroupDir)
+	klog.V(4).Infof("************podCPUSetCgroupRootDir is %v\n",podCPUSetCgroupRootDir())
 
 	if len(pod.Status.ContainerStatuses) <= 0 {
 		// container not created, skip until container is created because container runtime is unknown
@@ -70,6 +71,8 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 		}
 		containerSubDirNames[containerDirName] = struct{}{}
 		containerRuntime = runtimeType
+		klog.V(4).Infof("************containerSubDirNames is %v\n",containerSubDirNames[])
+		klog.V(4).Infof("************containerRuntime is %v\n",containerRuntime)
 	}
 
 	sandboxCandidates := make([]string, 0)

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -78,7 +78,7 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 		if !containerDir.IsDir() {
 			continue
 		}
-		containerDirName = containerDir.Name()
+		var containerDirName = containerDir.Name()
 		if _, exist := containerSubDirNames[containerDirName]; !exist {
 			if containerDirName.HasSuffix(".scope") {
 				sandboxCandidates = append(sandboxCandidates, containerDirName)

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -54,7 +54,7 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 	cpuSetCgroupRootDir := system.GetRootCgroupSubfsDir(system.CgroupCPUSetDir)
 	podCgroupDir := GetPodCgroupParentDir(pod)
 	podCPUSetCgroupRootDir := filepath.Join(cpuSetCgroupRootDir, podCgroupDir)
-	klog.V(4).Infof("************podCPUSetCgroupRootDir is %v\n",podCPUSetCgroupRootDir())
+	klog.V(4).Infof("************podCPUSetCgroupRootDir is %v\n",podCPUSetCgroupRootDir)
 
 	if len(pod.Status.ContainerStatuses) <= 0 {
 		// container not created, skip until container is created because container runtime is unknown

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -21,10 +21,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"k8s.io/klog/v2"
 
 	corev1 "k8s.io/api/core/v1"
-	
 
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )
@@ -54,7 +52,6 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 	cpuSetCgroupRootDir := system.GetRootCgroupSubfsDir(system.CgroupCPUSetDir)
 	podCgroupDir := GetPodCgroupParentDir(pod)
 	podCPUSetCgroupRootDir := filepath.Join(cpuSetCgroupRootDir, podCgroupDir)
-	klog.V(4).Infof("************podCPUSetCgroupRootDir is %v\n",podCPUSetCgroupRootDir)
 
 	if len(pod.Status.ContainerStatuses) <= 0 {
 		// container not created, skip until container is created because container runtime is unknown
@@ -71,8 +68,6 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 		}
 		containerSubDirNames[containerDirName] = struct{}{}
 		containerRuntime = runtimeType
-		klog.V(4).Infof("************containerSubDirNames is %v\n",containerSubDirNames)
-		klog.V(4).Infof("************containerRuntime is %v\n",containerRuntime)
 	}
 
 	sandboxCandidates := make([]string, 0)
@@ -85,11 +80,10 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 			continue
 		}
 		if _, exist := containerSubDirNames[containerDir.Name()]; !exist {
-			klog.V(4).Infof("************Container Sub Dir Name is %v\n",containerDir.Name())
 			if strings.HasPrefix(containerDir.Name(), "crio-") {
-				if strings.HasSuffix(containerDir.Name(), ".scope") {
+				if ! strings.HasSuffix(containerDir.Name(), ".scope") {
 					sandboxCandidates = append(sandboxCandidates, containerDir.Name())
-					}
+					} 
 			}else	{
 					sandboxCandidates = append(sandboxCandidates, containerDir.Name())
 				}

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -80,7 +80,7 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 			continue
 		}
 		if _, exist := containerSubDirNames[containerDir.Name()]; !exist {
-			fmt.Sprintf("************Container Sub Dir Name is %s\n",containerDir.Name())
+			log.Printf("************Container Sub Dir Name is %s\n",containerDir.Name())
 			if strings.HasPrefix(containerDir.Name(), "crio-") {
 				if strings.HasSuffix(containerDir.Name(), ".scope") {
 					sandboxCandidates = append(sandboxCandidates, containerDir.Name())

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -80,7 +80,7 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 			continue
 		}
 		if _, exist := containerSubDirNames[containerDir.Name()]; !exist {
-			fmt.Errorf("************Container Sub Dir Name is %v\n",containerDir.Name())
+			klog.V(4).Infof("************Container Sub Dir Name is %v\n",containerDir.Name())
 			if strings.HasPrefix(containerDir.Name(), "crio-") {
 				if strings.HasSuffix(containerDir.Name(), ".scope") {
 					sandboxCandidates = append(sandboxCandidates, containerDir.Name())

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -79,11 +79,15 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 		if !containerDir.IsDir() {
 			continue
 		}
-		var containerDirName = containerDir.Name()
-		if _, exist := containerSubDirNames[containerDirName]; !exist {
-			if strings.HasSuffix(containerDirName,".scope") {
-				sandboxCandidates = append(sandboxCandidates, containerDirName)
-			}
+		if _, exist := containerSubDirNames[containerDir.Name()]; !exist {
+			fmt.Sprintf("************Container Sub Dir Name is %s\n",containerDir.Name())
+			if strings.HasPrefix(containerDir.Name(), "crio-") {
+				if strings.HasSuffix(containerDir.Name(), ".scope") {
+					sandboxCandidates = append(sandboxCandidates, containerDir.Name())
+					}
+			}else	{
+					sandboxCandidates = append(sandboxCandidates, containerDir.Name())
+				}
 		}
 	}
 

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -71,7 +71,7 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 		}
 		containerSubDirNames[containerDirName] = struct{}{}
 		containerRuntime = runtimeType
-		klog.V(4).Infof("************containerSubDirNames is %v\n",containerSubDirNames[])
+		klog.V(4).Infof("************containerSubDirNames is %v\n",containerSubDirNames)
 		klog.V(4).Infof("************containerRuntime is %v\n",containerRuntime)
 	}
 

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -80,7 +81,7 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 		}
 		var containerDirName = containerDir.Name()
 		if _, exist := containerSubDirNames[containerDirName]; !exist {
-			if containerDirName.HasSuffix(".scope") {
+			if strings.HasSuffix(containerDirName,".scope") {
 				sandboxCandidates = append(sandboxCandidates, containerDirName)
 			}
 		}

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -80,7 +80,7 @@ func GetPodSandboxContainerID(pod *corev1.Pod) (string, error) {
 			continue
 		}
 		if _, exist := containerSubDirNames[containerDir.Name()]; !exist {
-			log.Printf("************Container Sub Dir Name is %s\n",containerDir.Name())
+			fmt.Errorf("************Container Sub Dir Name is %v\n",containerDir.Name())
 			if strings.HasPrefix(containerDir.Name(), "crio-") {
 				if strings.HasSuffix(containerDir.Name(), ".scope") {
 					sandboxCandidates = append(sandboxCandidates, containerDir.Name())

--- a/pkg/koordlet/util/pod.go
+++ b/pkg/koordlet/util/pod.go
@@ -21,8 +21,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"k8s.io/klog/v2"
 
 	corev1 "k8s.io/api/core/v1"
+	
 
 	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
 )

--- a/pkg/koordlet/util/runtime/handler/crio_runtime.go
+++ b/pkg/koordlet/util/runtime/handler/crio_runtime.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+
+func GetCrioEndpoint() string {
+	return filepath.Join(system.Conf.VarRunRootDir, "crio/crio.sock")
+}
+
+func GetCrioEndpoint2() string {
+	return filepath.Join(system.Conf.VarRunRootDir, "crio.sock")
+}
+
+type CrioRuntimeHandler struct {
+	runtimeServiceClient runtimeapi.RuntimeServiceClient
+	timeout              time.Duration
+	endpoint             string
+}
+
+func NewCrioRuntimeHandler(endpoint string) (ContainerRuntimeHandler, error) {
+	ep := strings.TrimPrefix(endpoint, "unix://")
+	if _, err := os.Stat(ep); err != nil {
+		return nil, err
+	}
+
+	client, err := getRuntimeClient(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CrioRuntimeHandler{
+		runtimeServiceClient: client,
+		timeout:              defaultConnectionTimeout,
+		endpoint:             endpoint,
+	}, nil
+}
+
+func (c *CrioRuntimeHandler) StopContainer(containerID string, timeout int64) error {
+	if containerID == "" {
+		return fmt.Errorf("containerID cannot be empty")
+	}
+	t := c.timeout + time.Duration(timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), t)
+	defer cancel()
+
+	request := &runtimeapi.StopContainerRequest{
+		ContainerId: containerID,
+		Timeout:     timeout,
+	}
+	_, err := c.runtimeServiceClient.StopContainer(ctx, request)
+	return err
+}
+
+
+func (c *CrioRuntimeHandler) UpdateContainerResources(containerID string, opts UpdateOptions) error {
+	if containerID == "" {
+		return fmt.Errorf("containerID cannot be empty")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+	request := &runtimeapi.UpdateContainerResourcesRequest{
+		ContainerId: containerID,
+		Linux: &runtimeapi.LinuxContainerResources{
+			CpuPeriod:          opts.CPUPeriod,
+			CpuQuota:           opts.CPUQuota,
+			CpuShares:          opts.CPUShares,
+			CpusetCpus:         opts.CpusetCpus,
+			CpusetMems:         opts.CpusetMems,
+			MemoryLimitInBytes: opts.MemoryLimitInBytes,
+			OomScoreAdj:        opts.OomScoreAdj,
+		},
+	}
+	_, err := c.runtimeServiceClient.UpdateContainerResources(ctx, request)
+	return err
+}

--- a/pkg/koordlet/util/runtime/handler/crio_runtime_test.go
+++ b/pkg/koordlet/util/runtime/handler/crio_runtime_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+
+	mockclient "github.com/koordinator-sh/koordinator/pkg/koordlet/util/runtime/handler/mockclient"
+	"github.com/koordinator-sh/koordinator/pkg/koordlet/util/system"
+)
+
+func Test_NewCrioRuntimeHandler(t *testing.T) {
+	stubs := gostub.Stub(&GrpcDial, func(context context.Context, target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+		return &grpc.ClientConn{}, nil
+	})
+	defer stubs.Reset()
+
+	helper := system.NewFileTestUtil(t)
+	defer helper.Cleanup()
+
+	helper.WriteFileContents("/var/run/crio/crio.sock", "test")
+	system.Conf.VarRunRootDir = filepath.Join(helper.TempDir, "/var/run")
+	CrioEndpoint1 := GetCrioEndpoint()
+	unixEndPoint := fmt.Sprintf("unix://%s", CrioEndpoint1)
+	crioRuntime, err := NewCrioRuntimeHandler(unixEndPoint)
+	assert.NoError(t, err)
+	assert.NotNil(t, crioRuntime)
+
+	// custom VarRunRootDir
+	helper.WriteFileContents("/host-var-run/crio/crio.sock", "test1")
+	system.Conf.VarRunRootDir = filepath.Join(helper.TempDir, "/host-var-run")
+	CrioEndpoint1 = GetCrioEndpoint()
+	unixEndPoint = fmt.Sprintf("unix://%s", CrioEndpoint1)
+	crioRuntime, err = NewCrioRuntimeHandler(unixEndPoint)
+	assert.NoError(t, err)
+	assert.NotNil(t, crioRuntime)
+}
+
+func Test_Crio_StopContainer(t *testing.T) {
+	type args struct {
+		name         string
+		containerId  string
+		runtimeError error
+		expectError  bool
+	}
+	tests := []args{
+		{
+			name:         "test_stopContainer_success",
+			containerId:  "test_container_id",
+			runtimeError: nil,
+			expectError:  false,
+		},
+		{
+			name:         "test_stopContainer_fail",
+			containerId:  "test_container_id",
+			runtimeError: fmt.Errorf("stopContainer error"),
+			expectError:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctl := gomock.NewController(t)
+			defer ctl.Finish()
+			mockRuntimeClient := mockclient.NewMockRuntimeServiceClient(ctl)
+			mockRuntimeClient.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(nil, tt.runtimeError)
+
+			runtimeHandler := ContainerdRuntimeHandler{runtimeServiceClient: mockRuntimeClient, timeout: 1, endpoint: GetCrioEndpoint()}
+			gotErr := runtimeHandler.StopContainer(tt.containerId, 1)
+			assert.Equal(t, gotErr != nil, tt.expectError)
+
+		})
+	}
+}
+
+func Test_Crio_UpdateContainerResources(t *testing.T) {
+	type args struct {
+		name         string
+		containerId  string
+		runtimeError error
+		expectError  bool
+	}
+	tests := []args{
+		{
+			name:         "test_UpdateContainerResources_success",
+			containerId:  "test_container_id",
+			runtimeError: nil,
+			expectError:  false,
+		},
+		{
+			name:         "test_UpdateContainerResources_fail",
+			containerId:  "test_container_id",
+			runtimeError: fmt.Errorf("UpdateContainerResources error"),
+			expectError:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctl := gomock.NewController(t)
+			defer ctl.Finish()
+			mockRuntimeClient := mockclient.NewMockRuntimeServiceClient(ctl)
+			mockRuntimeClient.EXPECT().UpdateContainerResources(gomock.Any(), gomock.Any()).Return(nil, tt.runtimeError)
+
+			runtimeHandler := ContainerdRuntimeHandler{runtimeServiceClient: mockRuntimeClient, timeout: 1, endpoint: GetCrioEndpoint()}
+			gotErr := runtimeHandler.UpdateContainerResources(tt.containerId, UpdateOptions{})
+			assert.Equal(t, tt.expectError, gotErr != nil)
+		})
+	}
+}

--- a/pkg/koordlet/util/runtime/runtime_test.go
+++ b/pkg/koordlet/util/runtime/runtime_test.go
@@ -96,6 +96,20 @@ func Test_GetRuntimeHandler(t *testing.T) {
 			expectErr:            false,
 		},
 		{
+			name:                 "test_/var/run/crio.sock",
+			endPoint:             "/var/run/crio.sock",
+			runtimeType:          "cri-o",
+			expectRuntimeHandler: "CrioRuntimeHandler",
+			expectErr:            false,
+		},
+		{
+			name:                 "test_/var/run/crio/crio.sock",
+			endPoint:             "/var/run/crio/crio.sock",
+			runtimeType:          "cri-o",
+			expectRuntimeHandler: "CrioRuntimeHandler",
+			expectErr:            false,
+		},
+		{
 			name:                 "custom containerd",
 			endPoint:             "/var/run/test1/containerd.sock",
 			flag:                 "test1/containerd.sock",
@@ -117,6 +131,14 @@ func Test_GetRuntimeHandler(t *testing.T) {
 			flag:                 "test3/pouchcri.sock",
 			runtimeType:          "pouch",
 			expectRuntimeHandler: "PouchRuntimeHandler",
+			expectErr:            false,
+		},
+		{
+			name:                 "custom crio",
+			endPoint:             "/var/run/test4/crio.sock",
+			flag:                 "test4/crio.sock",
+			runtimeType:          "cri-o",
+			expectRuntimeHandler: "CrioRuntimeHandler",
 			expectErr:            false,
 		},
 	}

--- a/pkg/koordlet/util/system/cgroup_driver.go
+++ b/pkg/koordlet/util/system/cgroup_driver.go
@@ -50,6 +50,7 @@ const (
 	RuntimeTypeDocker     = "docker"
 	RuntimeTypeContainerd = "containerd"
 	RuntimeTypePouch      = "pouch"
+        RuntimeTypeCrio       = "cri-o"
 	RuntimeTypeUnknown    = "unknown"
 )
 
@@ -106,6 +107,8 @@ var cgroupPathFormatterInSystemd = Formatter{
 			return RuntimeTypeContainerd, fmt.Sprintf("cri-containerd-%s.scope", hashID[1]), nil
 		case RuntimeTypePouch:
 			return RuntimeTypePouch, fmt.Sprintf("pouch-%s.scope", hashID[1]), nil
+                case RuntimeTypeCrio:
+                        return RuntimeTypeCrio, fmt.Sprintf("crio-%s.scope", hashID[1]), nil
 		default:
 			return RuntimeTypeUnknown, "", fmt.Errorf("unknown container protocol %s", id)
 		}
@@ -123,7 +126,6 @@ var cgroupPathFormatterInSystemd = Formatter{
 				prefix: "kubepods-burstable-pod",
 				suffix: ".slice",
 			},
-
 			{
 				prefix: "kubepods-pod",
 				suffix: ".slice",
@@ -150,12 +152,19 @@ var cgroupPathFormatterInSystemd = Formatter{
 				prefix: "cri-containerd-",
 				suffix: ".scope",
 			},
+			{
+				prefix: "crio-",
+				suffix: ".scope",
+			},
 		}
 
 		for i := range patterns {
 			if strings.HasPrefix(basename, patterns[i].prefix) && strings.HasSuffix(basename, patterns[i].suffix) {
 				return basename[len(patterns[i].prefix) : len(basename)-len(patterns[i].suffix)], nil
-			}
+			} 
+		}
+		if strings.HasPrefix(basename, "crio-") {
+			return basename[len("crio-") : len(basename)], nil
 		}
 		return "", fmt.Errorf("fail to parse container id: %v", basename)
 	},
@@ -182,7 +191,7 @@ var cgroupPathFormatterInCgroupfs = Formatter{
 		if len(hashID) < 2 {
 			return RuntimeTypeUnknown, "", fmt.Errorf("parse container id %s failed", id)
 		}
-		if hashID[0] == RuntimeTypeDocker || hashID[0] == RuntimeTypeContainerd || hashID[0] == RuntimeTypePouch {
+		if hashID[0] == RuntimeTypeDocker || hashID[0] == RuntimeTypeContainerd || hashID[0] == RuntimeTypePouch || hashID[0] == RuntimeTypeCrio {
 			return hashID[0], fmt.Sprintf("%s", hashID[1]), nil
 		} else {
 			return RuntimeTypeUnknown, "", fmt.Errorf("unknown container protocol %s", id)

--- a/pkg/koordlet/util/system/cgroup_driver_test.go
+++ b/pkg/koordlet/util/system/cgroup_driver_test.go
@@ -109,6 +109,10 @@ func Test_ParseContainerIDSystemd(t *testing.T) {
 			expeceted: "12345",
 		},
 		{
+			basename:  "crio-12345.scope",
+			expeceted: "12345",
+		},
+		{
 			basename:  "12345",
 			wantError: true,
 		},
@@ -180,6 +184,13 @@ func Test_SystemdCgroupPathContainerDirFn(t *testing.T) {
 			wantError:   false,
 		},
 		{
+			name:        "cri-o",
+			containerID: "cri-o://testCrioContainerID",
+			wantType:    RuntimeTypeCrio,
+			wantDirName: "crio-testCrioContainerID.scope",
+			wantError:   false,
+		},
+		{
 			name:        "bad-format",
 			containerID: "bad-format-id",
 			wantType:    RuntimeTypeUnknown,
@@ -222,6 +233,13 @@ func Test_CgroupfsCgroupPathContainerDirFn(t *testing.T) {
 			containerID: "pouch://testPouchContainerID",
 			wantType:    RuntimeTypePouch,
 			wantDirName: "testPouchContainerID",
+			wantError:   false,
+		},
+		{
+			name:        "cri-o",
+			containerID: "cri-o://testCrioContainerID",
+			wantType:    RuntimeTypeCrio,
+			wantDirName: "testCrioContainerID",
 			wantError:   false,
 		},
 		{

--- a/pkg/koordlet/util/system/config.go
+++ b/pkg/koordlet/util/system/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	ContainerdEndPoint string
 	PouchEndpoint      string
 	DockerEndPoint     string
+	CrioEndPoint     string
 	DefaultRuntimeType string
 }
 

--- a/pkg/koordlet/util/system/config.go
+++ b/pkg/koordlet/util/system/config.go
@@ -47,7 +47,7 @@ type Config struct {
 	ContainerdEndPoint string
 	PouchEndpoint      string
 	DockerEndPoint     string
-	CrioEndPoint     string
+	CrioEndPoint       string
 	DefaultRuntimeType string
 }
 

--- a/pkg/scheduler/plugins/coscheduling/coscheduling_test.go
+++ b/pkg/scheduler/plugins/coscheduling/coscheduling_test.go
@@ -382,12 +382,12 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority, but p1 is added to schedulingQ earlier than p2",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 framework.NewPodInfo(st.MakePod().Namespace(gangA_ns).Name("pod1").Priority(highPriority).Label(extension.LabelPodPriority, lowSubPriority).Obj()),
-				InitialAttemptTimestamp: earltTime,
+				PodInfo:   framework.NewPodInfo(st.MakePod().Namespace(gangA_ns).Name("pod1").Priority(highPriority).Label(extension.LabelPodPriority, lowSubPriority).Obj()),
+				Timestamp: earltTime,
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 framework.NewPodInfo(st.MakePod().Namespace(gangB_ns).Name("pod2").Priority(highPriority).Label(extension.LabelPodPriority, lowSubPriority).Obj()),
-				InitialAttemptTimestamp: lateTime,
+				PodInfo:   framework.NewPodInfo(st.MakePod().Namespace(gangB_ns).Name("pod2").Priority(highPriority).Label(extension.LabelPodPriority, lowSubPriority).Obj()),
+				Timestamp: lateTime,
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
 		},
@@ -404,12 +404,12 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority, p1 is added to schedulingQ earlier than p2",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 framework.NewPodInfo(st.MakePod().Namespace(gangB_ns).Name("pod1").Priority(highPriority).Obj()),
-				InitialAttemptTimestamp: earltTime,
+				PodInfo:   framework.NewPodInfo(st.MakePod().Namespace(gangB_ns).Name("pod1").Priority(highPriority).Obj()),
+				Timestamp: earltTime,
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 framework.NewPodInfo(st.MakePod().Namespace(gangA_ns).Name("pod2").Priority(highPriority).Obj()),
-				InitialAttemptTimestamp: lateTime,
+				PodInfo:   framework.NewPodInfo(st.MakePod().Namespace(gangA_ns).Name("pod2").Priority(highPriority).Obj()),
+				Timestamp: lateTime,
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
 		},
@@ -439,27 +439,27 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority. p2 is added to schedulingQ earlier than p1, p1 belongs to gangA and p2 belongs to gangB",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 framework.NewPodInfo(st.MakePod().Namespace(gangA_ns).Name("pod1").Priority(highPriority).Obj()),
-				InitialAttemptTimestamp: lateTime,
+				PodInfo:   framework.NewPodInfo(st.MakePod().Namespace(gangA_ns).Name("pod1").Priority(highPriority).Obj()),
+				Timestamp: lateTime,
 			},
 			annotations: map[string]string{extension.AnnotationGangName: "gangA"},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 framework.NewPodInfo(st.MakePod().Namespace(gangB_ns).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "gangB").Obj()),
-				InitialAttemptTimestamp: earltTime,
+				PodInfo:   framework.NewPodInfo(st.MakePod().Namespace(gangB_ns).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "gangB").Obj()),
+				Timestamp: earltTime,
 			},
-			expected: true, // p1 should be ahead of p2 in the queue
+			expected: false, // p1 should be ahead of p2 in the queue
 		},
 		{
 			name: "equal priority and creation time, both belongs to gangB",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 framework.NewPodInfo(st.MakePod().Namespace(gangB_ns).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "gangB").Obj()),
-				InitialAttemptTimestamp: lateTime,
+				PodInfo:   framework.NewPodInfo(st.MakePod().Namespace(gangB_ns).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "gangB").Obj()),
+				Timestamp: lateTime,
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 framework.NewPodInfo(st.MakePod().Namespace(gangB_ns).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "gangB").Obj()),
-				InitialAttemptTimestamp: earltTime,
+				PodInfo:   framework.NewPodInfo(st.MakePod().Namespace(gangB_ns).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "gangB").Obj()),
+				Timestamp: earltTime,
 			},
-			expected: true, // p1 should be ahead of p2 in the queue
+			expected: false,
 		},
 		{
 			name: "equal priority and creation time, both belongs to gangB, childScheduleCycle not equal",
@@ -478,14 +478,14 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority and creation time, p1 belongs to gangA that has been satisfied",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 framework.NewPodInfo(st.MakePod().Namespace(gangB_ns).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "gangD").Obj()),
-				InitialAttemptTimestamp: lateTime,
+				PodInfo:   framework.NewPodInfo(st.MakePod().Namespace(gangB_ns).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "gangD").Obj()),
+				Timestamp: lateTime,
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 framework.NewPodInfo(st.MakePod().Namespace(gangC_ns).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "gangC").Obj()),
-				InitialAttemptTimestamp: earltTime,
+				PodInfo:   framework.NewPodInfo(st.MakePod().Namespace(gangC_ns).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "gangC").Obj()),
+				Timestamp: earltTime,
 			},
-			expected: true, // p1 should be ahead of p2 in the queue
+			expected: false,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR will add koordlet support for the cri-o runtime ,  solve problems like "│ koordlet-vgmdg W0403 04:29:39.470690 919471 cgroup_reconcile.go:226] parse containerDir error! msg: unknown container protocol cri-o://088b531d2f86e63c6f35c823078 1be16fb0fe5788c14761812d1e8666596e0d
” running error.
### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Describe how to verify it
Deploying koordinatr in the cri-o v1.28 environment runs normally.
### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
